### PR TITLE
9479 Enable rubocop plugin `force_exclusion` flag

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -46,6 +46,7 @@ end
 # ------------------------------------------------------------------------------
 rubocop.lint(
   files: git.modified_files + git.added_files,
+  force_exclusion: true,
   report_danger: true
 )
 


### PR DESCRIPTION
[TP 9479](https://moneyadviceservice.tpondemand.com/entity/9479-configure-danger-gem-to-adhere-to)

This PR unblocks some PRs that have been blocked by the `danger-rubocop` plugin on the `fin_cap` project. The underlining problem is described in detail in the commit message and in this issue: https://github.com/rubocop-hq/rubocop/issues/2492#issuecomment-164375887