### PR TITLE
Add support folder to excluded list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,12 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Exclude:
     - '**/*_spec.rb'
+    - '**/support/*.rb'
 Metrics/BlockLength:
   Exclude:
     - '**/*_spec.rb'
     - '**/shared_examples/*.rb'
+    - '**/support/*.rb'
 Layout/ClassStructure:
   Enabled: true
   Categories:


### PR DESCRIPTION
- Exclude `**/support/*.rb` for `Metrics/ModuleLength` and `Metrics/BlockLength`