### PR TITLE
[DEV APPROVED] Fix rubocop wrong cop namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,14 +30,14 @@ Layout/ClassStructure:
   - private_methods
 Layout/DotPosition:
   EnforcedStyle: leading
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/CollectionMethods:
   Enabled: false
-Style/EmptyLineAfterGuardClause:
-  Enabled: true
 Style/FormatString:
   Enabled: false
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
EmptyLineAfterGuardClause was under Style namespace, triggering
".rubocop.yml: Style/EmptyLineAfterGuardClause has the wrong namespace
- should be Layout"

**Note**: Related with the change done upgrading the version in FINCAP: https://github.com/moneyadviceservice/fin_cap/pull/201