### PR TITLE
Add Dangerfile step checking version bump for engines

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -65,6 +65,22 @@ rubocop.lint(
   end
 end
 
+# ------------------------------------------------------------------------------
+# Do you have a Rails engine and you didn't bump the version?
+# ------------------------------------------------------------------------------
+is_an_engine = Dir.glob('lib/*/engine.rb').any?
+
+if is_an_engine
+  version_file = Dir.glob('lib/*/version.rb').first
+  unless git.modified_files.include?(version_file)
+    warn(
+      'It looks like this is a Rails engine, ' \
+      "but no changes to #{github.html_link(version_file)} detected. " \
+      'Did you forget to bump the version?'
+    )
+  end
+end
+
 if status_report.values.flatten.any?
   markdown(
     "At Money Advice Service, we use Danger gem, to ensure that our commits and pull requests follow " \


### PR DESCRIPTION
As the title says, this PR adds a step to check whether the version has been potentially bumped or not, **on Rails engines only**.

Example PR: https://github.com/moneyadviceservice/pacs/pull/38

Previous abandoned attempt at addressing this: https://github.com/moneyadviceservice/pacs/pull/20

Example warning:

<img width="866" alt="screen shot 2018-09-25 at 12 52 07" src="https://user-images.githubusercontent.com/9043263/46018070-f4f18680-c0d0-11e8-9160-3d972746ed80.png">
