### PR TITLE
[DEV APPROVED] - TP-8723: Extend Danger to warn against missing/differing translations

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -4,6 +4,9 @@
 BIG_PULL_REQUEST_LINES = 500
 APP_FILES = /^(app|lib)/
 TEST_FILES = /^(features|spec|test)/
+ENGLISH_LOCALE_FILE = 'config/locales/en.yml'.freeze
+WELSH_LOCALE_FILE =   'config/locales/cy.yml'.freeze
+LOCALE_FILES = [ENGLISH_LOCALE_FILE, WELSH_LOCALE_FILE].freeze
 
 # ------------------------------------------------------------------------------
 # Additional pull request data
@@ -77,6 +80,21 @@ if is_an_engine
       'It looks like this is a Rails engine, ' \
       "but no changes to #{github.html_link(version_file)} detected. " \
       'Did you forget to bump the version?'
+    )
+  end
+end
+
+# ------------------------------------------------------------------------------
+# Did you update only the English locale forgetting Welsh one?
+# ------------------------------------------------------------------------------
+english_and_welsh = LOCALE_FILES.all? { |f| File.file?(f) }
+
+if english_and_welsh
+  only_one_changed = git.modified_files.one? { |f| LOCALE_FILES.include?(f) }
+  if only_one_changed
+    warn(
+      'You modified the locale file only for one language. ' \
+      "Are you sure you're not missing Welsh or English translation?"
     )
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -86,7 +86,18 @@ end
 
 # ------------------------------------------------------------------------------
 # Did you update only the English locale forgetting Welsh one?
+# Did you name the English/Welsh keys in different way?
 # ------------------------------------------------------------------------------
+def get_all_keys(hash)
+  hash.each_with_object([]) do |(key, val), keys|
+    if val.is_a?(Hash)
+      keys.push(key, *get_all_keys(val))
+    else
+      keys << key
+    end
+  end
+end
+
 english_and_welsh = LOCALE_FILES.all? { |f| File.file?(f) }
 
 if english_and_welsh
@@ -96,6 +107,25 @@ if english_and_welsh
       'You modified the locale file only for one language. ' \
       "Are you sure you're not missing Welsh or English translation?"
     )
+  else
+    english_keys = get_all_keys(YAML.load_file(ENGLISH_LOCALE_FILE)['en'])
+    welsh_keys = get_all_keys(YAML.load_file(WELSH_LOCALE_FILE)['cy'])
+    missing_in_welsh = english_keys - welsh_keys
+    missing_in_english = welsh_keys - english_keys
+
+    if missing_in_welsh.any?
+      warn(
+        'English locale contains keys missing in Welsh locale. ' \
+        "Missing keys: #{missing_in_welsh}."
+      )
+    end
+
+    if missing_in_english.any?
+      warn(
+        'Welsh locale contains keys missing in English locale. ' \
+        "Missing keys: #{missing_in_english}."
+      )
+    end
   end
 end
 


### PR DESCRIPTION
[TP-8723](https://moneyadviceservice.tpondemand.com/entity/8723-create-language-yaml-file-comparator-script)

A common and painful mistake is to modify/extend the English locale
translations while forgetting to do the same for Welsh.
Then this is discovered during testing or even worse, already in
Staging/Production, and for a really tiny code change, the developer
needs to go again through all the release process, losing hours of
work.

This changes: 

- Add a new check into Danger to warn us
in the Pull Request when, having both Welsh and English locale files
present, we only pushed changes into one of the languages.

- Add a new check into Danger to warn us
in the Pull Request when, having both Welsh and English locale files
present, their keys don't match with each others.

In this way we aim to detect missing/wrong translations as soon as possible.


## Tested cases
Using PACS ad-hoc PR against local running version of Dangerfile.

### Welsh and English locales, but only English contains changes
**Result: Warning**
![screenshot from 2019-01-04 16-44-37](https://user-images.githubusercontent.com/1227578/50700389-574c1280-1042-11e9-9698-7b5db13a3268.png)

### Welsh and English locales, but only Welsh contains changes
**Result: Warning**
![screenshot from 2019-01-04 16-50-13](https://user-images.githubusercontent.com/1227578/50700542-b27e0500-1042-11e9-9ffa-5222e3e914c8.png)


### Welsh and English locales, but the changes are in codebase without touching locales
**Result: No warning**
![screenshot from 2019-01-04 16-46-48](https://user-images.githubusercontent.com/1227578/50700471-8bbfce80-1042-11e9-8185-4268d402e957.png)

### Welsh and English locales, changes on both locales
**Result: No warning**
![screenshot from 2019-01-04 16-48-53](https://user-images.githubusercontent.com/1227578/50700510-9f6b3500-1042-11e9-826a-b22df6e1515f.png)

### Welsh and English locales, changes on both locales, but keys differ between them
**Result: Warning**
![screenshot from 2019-01-07 14-48-17](https://user-images.githubusercontent.com/1227578/50775034-02500c80-128d-11e9-9ffd-9e0e7f1e93f5.png)

### Only English locale is present in the project, and has some changes
**Result: No warning**
![screenshot from 2019-01-04 16-52-32](https://user-images.githubusercontent.com/1227578/50700575-cb86b600-1042-11e9-93b2-a01656407925.png)




