### PR TITLE
[DEV APPROVED] Disable Style/NumericPredicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
+Style/NumericPredicate:
+  Enabled: false
 Style/OptionHash:
   Enabled: true
 Style/RaiseArgs:


### PR DESCRIPTION
Temporarily disable this rule during Ruby 2.6 upgrade. This file will be revisited post-upgrade.

Reason:

Rubocop enforces this:

`42.positive?`

Over this:

`42 > 0`

The `postive?` method doesn't exist in Ruby 2.2

I've added this PR to a running list of temporary changes that'll be looked at once Frontend is complete. https://moneyadviceservice.tpondemand.com/entity/10107-upgrade-frontend-repo-to-ruby-26