### PR TITLE
Disable Rubocop rules during Ruby upgrade

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Layout/DotPosition:
   EnforcedStyle: leading
 Layout/EmptyLineAfterGuardClause:
   Enabled: true
+Performance/RegexpMatch:
+  Enabled: false
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/ClassAndModuleChildren:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ Style/RaiseArgs:
   Enabled: false
 Style/RegexpLiteral:
   Enabled: false
+Style/SafeNavigation:
+  Enabled: false
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 Rails:


### PR DESCRIPTION
Temporarily disable these rules during Ruby 2.6 upgrade. This file will be
revisited post-upgrade.

Reasons:

Rubocop enforces use of `match?` instead of `match` in cases where the match data isn't being used. The boolean metod doesn't exist in Ruby 2.2.

Rubocop also replaces checks like this:
`forms.basic_info_form && @forms.basic_info_form.valid?`
with
`forms.basic_info_form&.valid?`
Again, the safe navigation syntax isn't available in 2.2.

I've added this PR to a running list of temporary changes that'll be looked at once Frontend is complete. https://moneyadviceservice.tpondemand.com/entity/10107-upgrade-frontend-repo-to-ruby-26