### PR TITLE
[DEV APPROVED] 10199 - Add missing TP Link warning to Danger rules

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,6 +7,7 @@ TEST_FILES = /^(features|spec|test)/
 ENGLISH_LOCALE_FILE = 'config/locales/en.yml'.freeze
 WELSH_LOCALE_FILE =   'config/locales/cy.yml'.freeze
 LOCALE_FILES = [ENGLISH_LOCALE_FILE, WELSH_LOCALE_FILE].freeze
+TARGETPROCESS_TICKET_TEXT = "moneyadviceservice.tpondemand.com"
 
 # ------------------------------------------------------------------------------
 # Additional pull request data
@@ -19,6 +20,17 @@ pr_url = github.pr_json["_links"]["html"]["href"]
 # ------------------------------------------------------------------------------
 has_app_changes = !git.modified_files.grep(APP_FILES).empty?
 has_test_changes = !git.modified_files.grep(TEST_FILES).empty?
+
+# ------------------------------------------------------------------------------
+# You forgot to link the Pull Request to a Targetprocess ticket?
+# ------------------------------------------------------------------------------
+unless github.pr_body.include?(TARGETPROCESS_TICKET_TEXT)
+  warn(
+    "There is no Targetprocess ticket associated to this PR. "\
+    "Please include the link to the corresponding task (TP-XXXX). "\
+    "If no ticket matches these changes consider creating one and linking it here."
+  )
+end
 
 # ------------------------------------------------------------------------------
 # You've made changes to app, but didn't write any tests?


### PR DESCRIPTION
[TP-10199](https://moneyadviceservice.tpondemand.com/entity/10199-danger-alert-for-missing-tp-link)

In order to give other developers context when visiting our PR, we
want to link our pull request to specific Targetprocess tickets, where
the context/requirements of the changes are better described and may
have further context in the comments between devs and product.

This adds a Danger alert into the Pull Request when it does not include
a link to our Targetprocess domain.

The implementation is quite relaxed so either copy the URL from the
browser or copying the proper ticket link will both be accepted.
As long as our TP subdomain shows up in the PR description we can
assume that is a proper link to a ticket.

Tested locally against PACS PR:
When TP link is missing:
![danger-tplink-warning](https://user-images.githubusercontent.com/1227578/51325457-dc80ef80-1a64-11e9-9499-ebb7305a3e70.png)

When TP link is present:
![danger-tplink-no-warning](https://user-images.githubusercontent.com/1227578/51325481-eacf0b80-1a64-11e9-9091-d6a33ab9611e.png)

