### PR TITLE
Exclude Gemfile.lock from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,4 @@ AllCops:
   - 'spec/dummy/script/**/*'
   - 'features/**/*'
   - 'node_modules/**/*'
+  - 'Gemfile.lock'


### PR DESCRIPTION
Danger generating lots of errors are been generated where `Gemfile.lock` is checked in the repo.

Adding it to exclude for `All Cops`